### PR TITLE
Fix code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/html/script.js
+++ b/html/script.js
@@ -16,7 +16,7 @@ function onload(){
   dingSound = document.getElementById("Ding");
 
   socket.on("join", function(room){
-    chatRoom.innerHTML = "Sala : " + room;
+    chatRoom.textContent = "Sala : " + room;
   })
 
   socket.on("recieve", function(message){
@@ -31,7 +31,7 @@ function onload(){
       messages.push(message);
     }
     for (i = 0; i < messages.length; i++){
-        document.getElementById("Message"+i).innerHTML = messages[i];
+        document.getElementById("Message"+i).textContent = messages[i];
         document.getElementById("Message"+i).style.color = "#303030";
     }
   })


### PR DESCRIPTION
Fixes [https://github.com/Jetrom17/chat/security/code-scanning/2](https://github.com/Jetrom17/chat/security/code-scanning/2)

To fix the problem, we need to ensure that any user-controlled data is properly sanitized or encoded before being inserted into the DOM. In this case, we should use `textContent` instead of `innerHTML` to prevent the browser from interpreting the data as HTML. This change will ensure that the data is treated as plain text, thus preventing any embedded scripts from being executed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
