### PR TITLE
Fix code scanning alert no. 1: Client-side cross-site scripting

### DIFF
--- a/html/script.js
+++ b/html/script.js
@@ -1,4 +1,5 @@
 var socket;
+import DOMPurify from 'dompurify';
 var usernameInput
 var chatIDInput;
 var messageInput;
@@ -16,7 +17,7 @@ function onload(){
   dingSound = document.getElementById("Ding");
 
   socket.on("join", function(room){
-    chatRoom.innerHTML = "Sala : " + room;
+    chatRoom.innerHTML = "Sala : " + DOMPurify.sanitize(room);
   })
 
   socket.on("recieve", function(message){

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "express": "^4.17.1",
     "html": "^1.0.0",
     "server": "^0.0.3",
-    "socket.io": "^2.3.0"
+    "socket.io": "^2.3.0",
+    "dompurify": "^3.2.2"
   }
 }


### PR DESCRIPTION
Fixes [https://github.com/Jetrom17/chat/security/code-scanning/1](https://github.com/Jetrom17/chat/security/code-scanning/1)

To fix the problem, we need to ensure that any user input or untrusted data is properly sanitized or encoded before being inserted into the DOM. In this case, we should use a library like `DOMPurify` to sanitize the `room` value before setting it to the `innerHTML` property.

- Import the `DOMPurify` library in the `html/script.js` file.
- Use `DOMPurify.sanitize` to sanitize the `room` value before setting it to the `innerHTML` property.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
